### PR TITLE
Update Micronaut to 4.2.0 and fix test

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-micronaut = "4.1.11"
+micronaut = "4.2.0"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.0.0"
-groovy = "4.0.13"
+micronaut-test = "4.1.0"
+groovy = "4.0.15"
 guava = "32.1.3-jre"
 managed-publicsuffixlist = "2.2.0"
 spock = "2.3-groovy-4.0"
 
 micronaut-reactor = "3.1.0"
-micronaut-serde = "2.3.0"
+micronaut-serde = "2.4.0"
 micronaut-session = "4.1.0"
 micronaut-validation = "4.2.0"
 

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/Book.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/Book.groovy
@@ -1,20 +1,6 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 class Book {
+
     String title
 }

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BookFetcher.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BookFetcher.groovy
@@ -1,20 +1,6 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 interface BookFetcher {
+
     List<String> findAll()
 }

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BookService.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BookService.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 import io.micronaut.context.annotation.Requires

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BooksClient.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BooksClient.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 import io.micronaut.context.annotation.Requires

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BooksController.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/BooksController.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 import groovy.transform.CompileStatic

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/Bootstrap.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/Bootstrap.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 import io.micronaut.context.annotation.Requires
@@ -30,7 +15,6 @@ class Bootstrap implements ApplicationEventListener<StartupEvent> {
 
     @Override
     void onApplicationEvent(StartupEvent event) {
-
         bookService.save('sherlock', 'Sherlock diary')
         bookService.save('watson', 'Watson diary')
     }

--- a/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/GatewayController.groovy
+++ b/multitenancy/src/test/groovy/io/micronaut/multitenancy/propagation/cookie/GatewayController.groovy
@@ -1,23 +1,10 @@
-/*
- * Copyright 2017-2020 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.multitenancy.propagation.cookie
 
 import io.micronaut.context.annotation.Requires
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 
 @Requires(property = 'spec.name', value = 'multitenancy.cookie.gateway')
 @Controller("/")
@@ -30,6 +17,7 @@ class GatewayController {
     }
 
     @Get("/")
+    @ExecuteOn(TaskExecutors.BLOCKING)
     List<String> index() {
         List<String> booksNames = bookFetcher.findAll()
 


### PR DESCRIPTION
There has been a change in Micronaut to throw an exception if you block the netty threads.

The test in CookieTenantResolverSpec was doing this, so this change adds an ExecuteOn annotation to GatewayController.

It also stops that test being Stepwise (as it makes debugging hard, and is unnecessary)

Also update libs to latests.